### PR TITLE
Fixed samenabling policy for non-OSGI environments

### DIFF
--- a/policies/samenabling-policy/src/main/java/org/talend/esb/policy/samenabling/SamEnablingInterceptorProvider.java
+++ b/policies/samenabling-policy/src/main/java/org/talend/esb/policy/samenabling/SamEnablingInterceptorProvider.java
@@ -52,7 +52,7 @@ public class SamEnablingInterceptorProvider extends
         
         // Try to initialize SAM Spring context for non-OSGi environments
         try {
-            if (this.getClass().getResource(AGENT_CONTEXT_PATH) != null) {
+            if (this.getClass().getResource("/"+AGENT_CONTEXT_PATH) != null) {
                 springContext = new ClassPathXmlApplicationContext(new String[] { AGENT_CONTEXT_PATH });
             }
         } catch (RuntimeException e) {


### PR DESCRIPTION
Currently call 

this.getClass().getResource(AGENT_CONTEXT_PATH)

always returns null, as there is no such resource as 

org/talend/esb/policy/samenabling/META-INF/tesb/agent-context.xml