### PR TITLE
TESB-18428 - Use original BC jar instead of ServiceMix

### DIFF
--- a/features/src/main/resources/features.xml
+++ b/features/src/main/resources/features.xml
@@ -222,13 +222,13 @@
   <feature name="tesb-security-common" version="${project.version}">
     <feature>cxf-rs-security-xml</feature>
     <feature>jasypt-encryption</feature>
-    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk15on/1.54</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk15on/${bouncycastle.version}</bundle>
     <bundle start-level='50'>mvn:org.talend.esb/security-common/${project.version}</bundle>
   </feature>
 
   <feature name="tesb-encryptor-command" version="${project.version}">
     <feature>jasypt-encryption</feature>
-    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk15on/1.54</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk15on/${bouncycastle.version}</bundle>
     <bundle start-level='50'>mvn:org.talend.esb/text-encryptor/${project.version}</bundle>
   </feature>
 

--- a/features/src/main/resources/features.xml
+++ b/features/src/main/resources/features.xml
@@ -222,13 +222,13 @@
   <feature name="tesb-security-common" version="${project.version}">
     <feature>cxf-rs-security-xml</feature>
     <feature>jasypt-encryption</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.bcprov-jdk15on/${bouncycastle.version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk15on/1.54</bundle>
     <bundle start-level='50'>mvn:org.talend.esb/security-common/${project.version}</bundle>
   </feature>
 
   <feature name="tesb-encryptor-command" version="${project.version}">
     <feature>jasypt-encryption</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.bcprov-jdk15on/${bouncycastle.version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk15on/1.54</bundle>
     <bundle start-level='50'>mvn:org.talend.esb/text-encryptor/${project.version}</bundle>
   </feature>
 

--- a/job/controller/pom.xml
+++ b/job/controller/pom.xml
@@ -83,8 +83,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.bcprov-jdk15on</artifactId>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <h2database.version>1.3.165</h2database.version>
         <jettison.version>1.3.7</jettison.version>
         <jasypt.version>1.9.2_1</jasypt.version>
-        <bouncycastle.version>1.52_1</bouncycastle.version>
+        <bouncycastle.version>1.54</bouncycastle.version>
         <hibersap.version>1.2.0</hibersap.version>
 
         <surefire.plugin.version>2.18.1</surefire.plugin.version>

--- a/security-common/pom.xml
+++ b/security-common/pom.xml
@@ -38,8 +38,8 @@
             <version>${jasypt.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.bcprov-jdk15on</artifactId>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
     </dependencies>

--- a/text-encryptor/pom.xml
+++ b/text-encryptor/pom.xml
@@ -24,8 +24,8 @@
             <version>${jasypt.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.bcprov-jdk15on</artifactId>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
The signature of the Bouncy Castle .jar file provided by ServiceMix cannot be verified (anymore). Instead we can start using the original BC .jar file again since that is a valid OSGi bundle nowadays.