### PR TITLE
 TESB-21321: Update NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,14 +19,18 @@ Licensed under the Apache License Version 2.0
 
 This product includes software developed at
 the Eclipse Foundation (http://www.eclipse.org/).
-Licensed under the Eclipse Public License - v 1.0Gson
+Licensed under the Eclipse Public License - v 1.0
 
 This product includes software developed at
 The Codehaus Foundation (http://www.codehaus.org/).
 Licensed under the Apache License Version 2.0
 
 This product includes software developed at
-Stax2 API (http://woodstox.codehaus.org/StAX2/)
+FasterXML (http://fasterxml.com).
+Licensed under the Apache License Version 2.0
+
+This product includes software (Stax2 API) developed at
+FasterXML (http://github.com/FasterXML/stax2-api)
 Licensed under the BSD License
 
 This product includes software developed at
@@ -37,7 +41,7 @@ This product includes software developed at
 OSGI (http://www.osgi.org)
 Licensed under the Apache License Version 2.0
 
-This product includes software (joda time, Code Generation Library, Dozer, FindBugs) developed at
+This product includes software developed at
 sourceforge (http://sourceforge.net)
 Licensed under the Apache License Version 2.0
 
@@ -51,10 +55,6 @@ Licensed under the Common Public License Version 1.0
 
 This product includes software developed at
 AOP alliance (http://aopalliance.sourceforge.net)
-
-This product includes software JTidy developed at
-sourceforge (http://jtidy.sourceforge.net)
-Licensed under the Java HTML Tidy License
 
 This product includes software developed at
 aQute (http://www.aqute.biz/)
@@ -80,7 +80,7 @@ This product includes software (JavaBeans Activation Framework) developed at
 Sun (http://java.sun.com/)
 Licensed under the Common Development and Distribution License (CDDL) v1.0
 
-This product includes software (JavaMail API, JAXB) developed at
+This product includes software (Java Servlet API, JAXB) developed at
 GlassFish (http://glassfish.java.net/)
 Licensed under the Common Development and Distribution License (CDDL) v1.0
 
@@ -96,16 +96,8 @@ This product includes software developed at
 Jaxen (http://jaxen.org/)
 Licensed under the Apache License 2.0.
 
-This product includes software developed at
-Gson (http://code.google.com/p/google-gson)
-Licensed under the Apache License 2.0.
-
-This product includes software developed at
-Guava: Google Core Libraries for Java (http://code.google.com/p/guava-libraries/guava)
-Licensed under the Apache License 2.0.
-
-This product includes software developed at
-Objenesis (http://code.google.com/p/objenesis)
+This product includes software (Gson, Guava) developed at
+Google Inc (http://code.google.com/)
 Licensed under the Apache License 2.0.
 
 This product includes software developed at
@@ -113,11 +105,7 @@ Hamcrest (http://code.google.com/p/hamcrest)
 Licensed under the New BSD License.
 
 This product includes software developed at
-JCraft (http://www.jcraft.com)
-Licensed under the BSD License.
-
-This product includes software developed at
-Hazelcast (http://www.hazelcast.com)
+Hazelcast, Inc (http://www.hazelcast.com)
 Licensed under the Apache License 2.0.
 
 This product includes software developed at
@@ -125,11 +113,11 @@ Jolokia (http://www.jolokia.org)
 Licensed under the Apache License 2.0.
 
 This product includes software developed at
-Jruby (http://bitnami.org/stack/jrubystack)
-Licensed under the Apache License 2.0.
+Jruby (http://jruby.org)
+Licensed under the Eclipse Public License - v 1.0.
 
 This product includes software developed at
-JiBX (http://jibx.sourceforge.net)
+JiBX (http://www.jibx.org)
 Licensed under the BSD License.
 
 This product includes software developed at
@@ -193,7 +181,7 @@ HyperSQL Database (http://hsqldb.org)
 Licensed under HSQLDB License, BSD License
 
 This product includes software developed at
-JASYPT: Java Simplified Encryption (http://www.jasypt.org)
+The JASYPT team (http://www.jasypt.org)
 Licensed under the Apache License 2.0.
 
 This product includes software OpenSAML-J, OpenWS, XMLTooling-J developed at
@@ -229,9 +217,22 @@ Cryptacular (http://www.cryptacular.org)
 Licensed under the Apache License 2.0.
 
 This product includes software developed at
-hawtbuf (http://hawtbuf.fusesource.org/hawtbuf)
+ASM (http://asm.objectweb.org/asm/)
+Licensed under the BSD License.
+
+This product includes software developed at
+Dropwizard Team (http://metrics.dropwizard.io/)
 Licensed under the Apache License 2.0.
 
 This product includes software developed at
-ASM (http://asm.objectweb.org/asm/)
-Licensed under the BSD License.
+Day Software (http://www.day.com)
+Licensed under the Day Specification License.
+
+This product includes software developed at
+Oracle Corporation (http://www.oracle.com)
+Licensed under the Common Development and Distribution License (CDDL) v1.1
+
+This product includes software (Joda-Time) developed at
+Joda.org (http://www.joda.org)
+Licensed under the Apache License Version 2.0
+

--- a/NOTICE
+++ b/NOTICE
@@ -41,10 +41,6 @@ This product includes software developed at
 OSGI (http://www.osgi.org)
 Licensed under the Apache License Version 2.0
 
-This product includes software developed at
-sourceforge (http://sourceforge.net)
-Licensed under the Apache License Version 2.0
-
 This product includes software (JLine) developed at
 sourceforge (http://sourceforge.net)
 Licensed under the BSD License
@@ -224,9 +220,9 @@ This product includes software developed at
 Dropwizard Team (http://metrics.dropwizard.io/)
 Licensed under the Apache License 2.0.
 
-This product includes software developed at
-Day Software (http://www.day.com)
-Licensed under the Day Specification License.
+This product includes software (Joda-Time) developed at
+Jackrabbit (http://jackrabbit.apache.org)
+Licensed under the Apache License Version 2.0
 
 This product includes software developed at
 Oracle Corporation (http://www.oracle.com)

--- a/NOTICE
+++ b/NOTICE
@@ -236,3 +236,350 @@ This product includes software (Joda-Time) developed at
 Joda.org (http://www.joda.org)
 Licensed under the Apache License Version 2.0
 
+This product includes software developed at
+OpenMUC Team (http://www.openmuc.org/)
+Licensed under the Mozilla Public License v2.0
+
+This product includes software developed at
+Asterisk-Java (http://asterisk-java.org/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Atmosphere Framework (http://async-io.org/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+xerial.org (http://xerial.org/software/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+BeanIO (http://beanio.org/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+BeanstalkClient (https://github.com/jpeffer/JavaBeanstalkClient)
+Licensed under the 3-Clause BSD License
+
+This product includes software developed at
+JCommander (http://jcommander.org/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Boon (https://github.com/boonproject/boon)
+Licensed under the Apache License Version 2.0
+
+This product includes software (Simple API for CSS) developed at
+World Wide Web Consortium (http://www.w3.org/)
+Licensed under the W3C Software License
+
+This product includes software developed at
+jose.4.j (https://bitbucket.org/b_c/jose4j)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Box (http://opensource.box.com/box-java-sdk/)
+Licensed under the Apache License Version 2.0
+
+This product includes software (Braintree Gateway Java Client Library) developed at
+Braintree (https://www.braintreegateway.com)
+Licensed under the MIT license
+
+This product includes software developed at
+Caffeine (https://github.com/ben-manes/caffeine)
+Licensed under the Apache License Version 2.0
+
+This product includes software (Cassandra Java Driver) developed at
+DataStax (https://github.com/datastax/java-driver)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Chronicle (http://chronicle.software/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Chemouni Uriel (http://www.minidev.net/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+jsoup (https://jsoup.org/)
+Licensed under the MIT License
+
+This product includes software developed at
+Bean Validation (http://beanvalidation.org)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Hibernate Validator (http://hibernate.org/validator/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+JBoss by Red Hat (http://www.jboss.org)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+CometD (https://cometd.org/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Couchbase (https://developer.couchbase.com/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Disruptor Framework (http://lmax-exchange.github.com/disruptor)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Dozer (https://dozermapper.github.io/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Dropbox (https://www.dropbox.com/developers/core)
+Licensed under the MIT License
+
+This product includes software developed at
+ElSql (https://github.com/OpenGamma/ElSql)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Elasticsearch (http://www.elastic.co)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+etcd4j (https://github.com/jurmous/etcd4j)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Facebook4J (http://facebook4j.org/)
+Licensed under the Apache License Version 2.0
+
+This product includes software (Fastjson) developed at
+Alibaba Group (https://github.com/alibaba/fastjson)
+Licensed under the Apache License Version 2.0
+
+This product includes software (FlatPack) developed at
+FlatPack (http://flatpack.sourceforge.net/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+FreeMarker (http://freemarker.org/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Ganglia (http://ganglia.info/)
+Licensed under the MIT License
+
+This product includes software developed at
+gRPC (https://grpc.io/)
+Licensed under the Apache License Version 2.0
+
+This product includes software (Hessian) developed at
+Caucho Technology, Inc (http://hessian.caucho.com)
+Licensed under the Apache License Version 1.1
+
+This product includes software developed at
+HAPI (http://hl7api.sourceforge.net/)
+Licensed under the Mozilla Public License 1.1
+
+This product includes software developed at
+Hystrix (https://github.com/Netflix/Hystrix)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+InfluxData (http://www.influxdb.org)
+Licensed under the MIT License
+
+This product includes software developed at
+irclib (http://moepii.sourceforge.net/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Iron MQ (http://www.iron.io/mq)
+Licensed under the BSD 2-Clause License
+
+This product includes software developed at
+JGroups (http://www.jgroups.org)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Jolt (https://github.com/bazaarvoice/jolt)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+JsonPath (https://github.com/jayway/JsonPath)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+JT400 (http://jt400.sourceforge.net/)
+Licensed under the IBM Public License Version 1.0
+
+This product includes software (JUEL) developed at
+Odysseus Software GmbH (http://www.odysseus.de/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+krati (http://sna-projects.com/krati)
+Licensed under the Apache License Version 2.0
+
+This product includes software (Fabric8) developed at
+Red Hat (http://fabric8.io)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+LevelDB in Java (https://github.com/dain/leveldb)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Compress-LZF (http://github.com/ning/compress)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+MongoDB (http://www.mongodb.org)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+JSend NSCA (https://github.com/jsendnsca/jsendnsca)
+Licensed under the Apache License Version 2.0
+
+This product includes software (jnats) developed at
+Apcera, Inc. (http://nats.io)
+Licensed under the MIT License
+
+This product includes software (OGNL) developed at
+OpenSymphony (http://www.opensymphony.com)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+OpenShift Java Client (http://openshift.redhat.com)
+Licensed under the Eclipse Public License v1.0
+
+This product includes software developed at
+OpenStack Java API (http://github.com/gondor/openstack4j/)
+Licensed under the MIT License
+
+This product includes software developed at
+Okio (https://github.com/square/okio)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+OkHttp (https://github.com/square/okhttp)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+OpenTracing (http://opentracing.io)
+Licensed under the Apache License Version 2.0
+
+This product includes software (PGJDBC-NG) developed at
+impossibl.com (http://www.impossibl.com)
+Licensed under the 3-Clause BSD License
+
+This product includes software developed at
+PubNub Java SDK (https://github.com/pubnub/java)
+Licensed under the MIT License
+
+This product includes software developed at
+Retrofit (http://github.com/square/retrofit/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Quartz (http://quartz-scheduler.org/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+QuickFIX/J (http://www.quickfixj.org)
+Licensed under the The QuickFIX Software License, Version 1.0
+
+This product includes software developed at
+RabbitMQ Java Client (http://www.rabbitmq.com)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Reactive Streams (http://www.reactive-streams.org/)
+Licensed under the CC0 1.0
+
+This product includes software developed at
+reactor (http://github.com/reactor)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+RxJava (https://github.com/ReactiveX/RxJava)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Saxonica (http://www.saxonica.com/)
+Licensed under the Mozilla Public License Version 2.0
+
+This product includes software (Scala) developed at
+LAMP/EPFL (http://www.scala-lang.org/)
+Licensed under the 3-Clause BSD License
+
+This product includes software developed at
+Rhino (https://developer.mozilla.org/en/Rhino)
+Licensed under the Mozilla Public License, Version 2.0
+
+This product includes software developed at
+SMPP (http://jsmpp.org)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+SnakeYAML (http://www.snakeyaml.org)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+SNMP4J (http://www.snmp4j.org)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Spark (http://www.sparkjava.com)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+StringTemplate 4 (http://www.stringtemplate.org)
+Licensed under the BSD licence
+
+This product includes software developed at
+Swagger Core (https://github.com/swagger-api/swagger-core)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+TagSoup (http://home.ccil.org/~cowan/XML/tagsoup/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Twilio (https://www.twilio.com)
+Licensed under the MIT License
+
+This product includes software developed at
+twitter4j (http://twitter4j.org/)
+Licensed under the Apache License Version 2.0
+
+This product includes software (uniVocity-parsers) developed at
+uniVocity Software Pty Ltd (www.univocity.com)
+Licensed under the Apache License Version 2.0
+
+This product includes software (UrlRewriteFilter) developed at
+Paul Tuckey (http://www.tuckey.org/urlrewrite/)
+Licensed under the BSD licence
+
+This product includes software developed at
+Vert.x Core (https://github.com/eclipse/vert.x)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+Smack (http://www.igniterealtime.org/projects/smack/)
+Licensed under the Apache License Version 2.0
+
+This product includes software developed at
+XStream (http://x-stream.github.io)
+Licensed under the BSD license
+
+This product includes software developed at
+Scribe OAuth (http://github.com/fernandezpablo85/scribe-java)
+Licensed under the MIT License
+
+This product includes software developed at
+Zendesk Java client (https://github.com/cloudbees/zendesk-java-client)
+Licensed under the Apache License Version 2.0
+
+This product includes software (Zipkin) developed at
+OpenZipkin (http://zipkin.io/)
+Licensed under the Apache License Version 2.0


### PR DESCRIPTION
NOTICE file has been updated from two sources (2 separate commits):

- from maven dependencies (entries are generated by maven-license-plugin)
- from Camel features descriptor, which brings a lot artifacts to our binary distribution package and they are not dependencies of our project in maven.

Additional processing done: try to aggregate entries by companies (like it's done for Apache, Eclipce, Google, etc)