### PR TITLE
fix(TESB-21976): Integrate patched servicemix bundles.

### DIFF
--- a/talend-esb/pom.xml
+++ b/talend-esb/pom.xml
@@ -42,6 +42,9 @@
         <pax-logging.version>1.10.1</pax-logging.version>
         <javax-annotation.version>1.3</javax-annotation.version>
         <qpid-jms.version>0.11.1</qpid-jms.version>
+        <fastjson.version>1.2.37_1</fastjson.version>
+        <sparkjava-core.version>2.6.0_1</sparkjava-core.version>
+        <mustache-compiler.version>0.9.5_1</mustache-compiler.version>
 	</properties>
 
 	<dependencies>
@@ -645,6 +648,30 @@
                                     <outputDirectory>target/dependencies</outputDirectory>
                                     <destFileName>qpid-jms-client-${qpid-jms.version}-tesb1.jar</destFileName>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.servicemix.bundles</groupId>
+                                    <artifactId>org.apache.servicemix.bundles.fastjson</artifactId>
+                                    <version>${fastjson.version}.tesb1</version>
+                                    <type>jar</type>
+                                    <outputDirectory>target/dependencies</outputDirectory>
+                                    <destFileName>org.apache.servicemix.bundles.fastjson-${fastjson.version}.tesb1.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.servicemix.bundles</groupId>
+                                    <artifactId>org.apache.servicemix.bundles.sparkjava-core</artifactId>
+                                    <version>${sparkjava-core.version}.tesb1</version>
+                                    <type>jar</type>
+                                    <outputDirectory>target/dependencies</outputDirectory>
+                                    <destFileName>org.apache.servicemix.bundles.sparkjava-core-${sparkjava-core.version}.tesb1.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.servicemix.bundles</groupId>
+                                    <artifactId>org.apache.servicemix.bundles.mustache-compiler</artifactId>
+                                    <version>${mustache-compiler.version}.tesb1</version>
+                                    <type>jar</type>
+                                    <outputDirectory>target/dependencies</outputDirectory>
+                                    <destFileName>org.apache.servicemix.bundles.mustache-compiler-${mustache-compiler.version}.tesb1.jar</destFileName>
+                                </artifactItem>
                                 <!-- Patch jackson-databind version (TESB-21628) -->
                                 <artifactItem>
                                     <groupId>org.apache.activemq</groupId>
@@ -954,6 +981,15 @@
                                     <replacefilter
                                         token="&gt;mvn:org.apache.qpid/qpid-jms-client/${qpid-jms.version}&lt;"
                                         value="&gt;mvn:org.apache.qpid/qpid-jms-client/${qpid-jms.version}-tesb1&lt;"/>
+                                    <replacefilter
+                                        token="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.fastjson/${fastjson.version}&lt;"
+                                        value="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.fastjson/${fastjson.version}.tesb1&lt;"/>
+                                    <replacefilter
+                                        token="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.sparkjava-core/${sparkjava-core.version}&lt;"
+                                        value="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.sparkjava-core/${sparkjava-core.version}.tesb1&lt;"/>
+                                    <replacefilter
+                                        token="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.mustache-compiler/${mustache-compiler.version}&lt;"
+                                        value="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.mustache-compiler/${mustache-compiler.version}.tesb1&lt;"/>
                                     <!-- Patch jackson-databind version (TESB-21628) -->
                                     <replacefilter
                                         token="&gt;mvn:com.fasterxml.jackson.core/jackson-databind/2.4.4&lt;"

--- a/talend-esb/src/main/descriptors/unix-bin.xml
+++ b/talend-esb/src/main/descriptors/unix-bin.xml
@@ -384,6 +384,9 @@
                 <exclude>org/apache/activemq/activemq-karaf/${activemq.version}/activemq-karaf-${activemq.version}-features.xml</exclude>
                 <exclude>org/apache/activemq/activemq-camel/${activemq.version}/**</exclude>
                 <exclude>org/apache/qpid/qpid-jms-client/${qpid-jms.version}/**</exclude>
+                <exclude>org/apache/servicemix/bundles/org.apache.servicemix.bundles.fastjson/${fastjson.version}/**</exclude>
+                <exclude>org/apache/servicemix/bundles/org.apache.servicemix.bundles.sparkjava-core/${sparkjava-core.version}/**</exclude>
+                <exclude>org/apache/servicemix/bundles/org.apache.servicemix.bundles.mustache-compiler/${mustache-compiler.version}/**</exclude>
                 <!-- Patch jackson-databind version (TESB-21628) -->
                 <exclude>org/apache/activemq/activemq-karaf/${activemq.version}/activemq-karaf-${activemq.version}-features-core.xml</exclude>
                 <exclude>com/fasterxml/jackson/core/jackson-databind/2.4.4/**</exclude>
@@ -564,6 +567,21 @@
         <file>
             <source>${basedir}/target/dependencies/qpid-jms-client-${qpid-jms.version}-tesb1.jar</source>
             <outputDirectory>/container/system/org/apache/qpid/qpid-jms-client/${qpid-jms.version}-tesb1/</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>${basedir}/target/dependencies/org.apache.servicemix.bundles.fastjson-${fastjson.version}.tesb1.jar</source>
+            <outputDirectory>/container/system/org/apache/servicemix/bundles/org.apache.servicemix.bundles.fastjson/${fastjson.version}.tesb1/</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>${basedir}/target/dependencies/org.apache.servicemix.bundles.sparkjava-core-${sparkjava-core.version}.tesb1.jar</source>
+            <outputDirectory>/container/system/org/apache/servicemix/bundles/org.apache.servicemix.bundles.sparkjava-core/${sparkjava-core.version}.tesb1/</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>${basedir}/target/dependencies/org.apache.servicemix.bundles.mustache-compiler-${mustache-compiler.version}.tesb1.jar</source>
+            <outputDirectory>/container/system/org/apache/servicemix/bundles/org.apache.servicemix.bundles.mustache-compiler/${mustache-compiler.version}.tesb1/</outputDirectory>
             <fileMode>0644</fileMode>
         </file>
         <!-- Patch jackson-databind version (TESB-21628) -->

--- a/talend-esb/src/main/descriptors/win-bin.xml
+++ b/talend-esb/src/main/descriptors/win-bin.xml
@@ -384,6 +384,9 @@
                 <exclude>org/apache/activemq/activemq-karaf/${activemq.version}/activemq-karaf-${activemq.version}-features.xml</exclude>
                 <exclude>org/apache/activemq/activemq-camel/${activemq.version}/**</exclude>
                 <exclude>org/apache/qpid/qpid-jms-client/${qpid-jms.version}/**</exclude>
+                <exclude>org/apache/servicemix/bundles/org.apache.servicemix.bundles.fastjson/${fastjson.version}/**</exclude>
+                <exclude>org/apache/servicemix/bundles/org.apache.servicemix.bundles.sparkjava-core/${sparkjava-core.version}/**</exclude>
+                <exclude>org/apache/servicemix/bundles/org.apache.servicemix.bundles.mustache-compiler/${mustache-compiler.version}/**</exclude>
                 <!-- Patch jackson-databind version (TESB-21628) -->
                 <exclude>org/apache/activemq/activemq-karaf/${activemq.version}/activemq-karaf-${activemq.version}-features-core.xml</exclude>
                 <exclude>com/fasterxml/jackson/core/jackson-databind/2.4.4/**</exclude>
@@ -564,6 +567,21 @@
         <file>
             <source>${basedir}/target/dependencies/qpid-jms-client-${qpid-jms.version}-tesb1.jar</source>
             <outputDirectory>/container/system/org/apache/qpid/qpid-jms-client/${qpid-jms.version}-tesb1/</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>${basedir}/target/dependencies/org.apache.servicemix.bundles.fastjson-${fastjson.version}.tesb1.jar</source>
+            <outputDirectory>/container/system/org/apache/servicemix/bundles/org.apache.servicemix.bundles.fastjson/${fastjson.version}.tesb1/</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>${basedir}/target/dependencies/org.apache.servicemix.bundles.sparkjava-core-${sparkjava-core.version}.tesb1.jar</source>
+            <outputDirectory>/container/system/org/apache/servicemix/bundles/org.apache.servicemix.bundles.sparkjava-core/${sparkjava-core.version}.tesb1/</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>${basedir}/target/dependencies/org.apache.servicemix.bundles.mustache-compiler-${mustache-compiler.version}.tesb1.jar</source>
+            <outputDirectory>/container/system/org/apache/servicemix/bundles/org.apache.servicemix.bundles.mustache-compiler/${mustache-compiler.version}.tesb1/</outputDirectory>
             <fileMode>0644</fileMode>
         </file>
         <!-- Patch jackson-databind version (TESB-21628) -->


### PR DESCRIPTION
It has been verified that TESB-21976 is caused by a manifest header in some servicemix bundles which does not syntactically conform to applicable standards. This issue is known to the servicemix developers and has been fixed for some, but not all affected libraries, which makes the present fix necessary while there is no servicemix bundles release which solves all these issues.

Review of the fix itself is not required because the fix follows an established procedure.