### PR TITLE
Fixed type name to enable correct runtime resolution of OAuthPermission

### DIFF
--- a/examples/cxf/jaxrs-oauth2/war/src/main/webapp/forms/oauthAuthorize.jsp
+++ b/examples/cxf/jaxrs-oauth2/war/src/main/webapp/forms/oauthAuthorize.jsp
@@ -1,4 +1,4 @@
-<%@ page import="javax.servlet.http.HttpServletRequest,org.apache.cxf.rs.security.oauth2.common.OAuthAuthorizationData,org.apache.cxf.rs.security.oauth2.common.Permission" %>
+<%@ page import="javax.servlet.http.HttpServletRequest,org.apache.cxf.rs.security.oauth2.common.OAuthAuthorizationData,org.apache.cxf.rs.security.oauth2.common.OAuthPermission" %>
 
 <%
     OAuthAuthorizationData data = (OAuthAuthorizationData)request.getAttribute("oauthauthorizationdata");
@@ -41,7 +41,7 @@
                         <p/>
                         <table> 
                             <%
-                               for (Permission perm : data.getPermissions()) {
+                               for (OAuthPermission perm : data.getPermissions()) {
                             %>
                                <tr>
                                 <td>


### PR DESCRIPTION
When running the sample, an error is thrown that only types can be imported, but Permission resolves to a package. Changed the type name accordingly so that sample runs properly.