### PR TITLE
TESB-23722 removed unsecure TLS filter configuration.

### DIFF
--- a/talend-esb/src/main/distribution/text/container/etc/org.apache.cxf.http.conduits-common.cfg
+++ b/talend-esb/src/main/distribution/text/container/etc/org.apache.cxf.http.conduits-common.cfg
@@ -32,4 +32,6 @@ tlsClientParameters.keyManagers.keyStore.file = ./etc/keystores/keystore.jks
 tlsClientParameters.keyManagers.keyPassword = password
 tlsClientParameters.trustManagers.keyPassword = password
 
-tlsClientParameters.cipherSuitesFilter.include = .*_EXPORT_.*,.*_EXPORT1024_.*,.*_WITH_DES_.*,.*_WITH_AES_.*,.*_WITH_NULL_.*,.*_DH_anon_.*
+# See http://cxf.apache.org/docs/tls-configuration.html for specific filters.
+# If nothing is set, cipher suites are used as configured in the JRE.
+#tlsClientParameters.cipherSuitesFilter.include = .*_WITH_AES_.*


### PR DESCRIPTION
A TLS client cipher suite filter configuration allowing unsecure cipher suites has been removed, and some explations regarding cipher suite filter configuration have been added as comments.