### PR TITLE
TESB-26996 upgrade xstream version to java8

### DIFF
--- a/talend-esb/pom.xml
+++ b/talend-esb/pom.xml
@@ -1520,9 +1520,10 @@
                                         value="mvn:org.ops4j.pax.web/pax-web-features/${pax-web.version}/xml/features"/>
                                 </replace>
                                 <replace file="target/dependencies/activemq-karaf-${activemq.version}-features-core.xml">
+									<!-- patch for the xstream version (TESB-26996) -->
                                     <replacefilter
                                         token="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.8_1&lt;"
-                                        value="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.10_1&lt;"/>
+                                        value="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream-java8/1.4.10_1&lt;"/>
                                     <!-- patch the jackson version (TESB-26035) -->
                                     <replacefilter
                                         token="mvn:com.fasterxml.jackson.core/jackson-core/2.9.8"

--- a/talend-esb/pom.xml
+++ b/talend-esb/pom.xml
@@ -1520,7 +1520,7 @@
                                         value="mvn:org.ops4j.pax.web/pax-web-features/${pax-web.version}/xml/features"/>
                                 </replace>
                                 <replace file="target/dependencies/activemq-karaf-${activemq.version}-features-core.xml">
-									<!-- patch for the xstream version (TESB-26996) -->
+                                <!-- patch for the xstream version (TESB-26996) -->
                                     <replacefilter
                                         token="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.8_1&lt;"
                                         value="&gt;mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream-java8/1.4.10_1&lt;"/>


### PR DESCRIPTION
change 
`mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.10_1` 
to 
`mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream-java8/1.4.10_1`

Or we get error `Caused by: java.lang.NoSuchMethodException: com.thoughtworks.xstream.mapper.LambdaMapper` if install activemq feature in Talend runtime and try to run OSGi with xstream.