### PR TITLE
TESB-27385: Runtime "org.ops4j.pax.logging.cfg" overwritten by Cloud-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     </developers>
 
     <properties>
+        <org.apache.karaf.config.core.tesb.version>4.2.7.tesb1</org.apache.karaf.config.core.tesb.version>
         <packages.version>${project.version}</packages.version>
         <cxf.version>3.3.4</cxf.version>
         <camel.version>2.24.2</camel.version>

--- a/talend-esb/pom.xml
+++ b/talend-esb/pom.xml
@@ -102,7 +102,7 @@
                                 <descriptor>mvn:org.apache.karaf.features/enterprise-legacy/${karaf.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.apache.jclouds.karaf/jclouds-karaf/${jclouds.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.apache.karaf.decanter/apache-karaf-decanter/${decanter.version}/xml/features</descriptor>
-<!--                                <descriptor>mvn:org.ops4j.pax.web/pax-web-features/${pax-web.version}/xml/features</descriptor> --> 
+<!--                                <descriptor>mvn:org.ops4j.pax.web/pax-web-features/${pax-web.version}/xml/features</descriptor> -->
 <!--                                 <descriptor>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.version}/xml/features</descriptor> -->
 <!--                                 <descriptor>mvn:org.apache.activemq/activemq-karaf/${activemq.version}/xml/features</descriptor> -->
 <!--                                 <descriptor>mvn:org.apache.camel.karaf/apache-camel/${camel.version}/xml/features</descriptor> -->
@@ -127,6 +127,7 @@
                                 <feature>jndi</feature>
                                 <feature>jms</feature>
                                 <feature>aries-blueprint-spring</feature>
+                                <feature>config</feature>
                                 <!-- ActiveMQ Features -->
                                 <feature>activemq</feature>
                                 <feature>activemq-blueprint</feature>
@@ -540,6 +541,15 @@
                                 </artifactItem>
                                 <!-- Workaround for Karaf libraries in features -->
                                 <artifactItem>
+                                    <groupId>org.apache.karaf.features</groupId>
+                                    <artifactId>standard</artifactId>
+                                    <version>${karaf.version}</version>
+                                    <type>xml</type>
+                                    <classifier>features</classifier>
+                                    <outputDirectory>target/dependencies</outputDirectory>
+                                    <destFileName>standard-${karaf.version}-features.xml</destFileName>
+                                </artifactItem>
+                                <artifactItem>
                                     <groupId>org.apache.karaf.diagnostic</groupId>
                                     <artifactId>org.apache.karaf.diagnostic.boot</artifactId>
                                     <version>${karaf.version}</version>
@@ -789,6 +799,13 @@
                                      <type>jar</type>
                                      <outputDirectory>target/dependencies</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.karaf.config</groupId>
+                                    <artifactId>org.apache.karaf.config.core</artifactId>
+                                    <version>${org.apache.karaf.config.core.tesb.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>target/dependencies</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -1011,6 +1028,11 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <target>
+                                <replace file="target/dependencies/standard-${karaf.version}-features.xml">
+                                    <replacefilter
+                                        token="mvn:org.apache.karaf.config/org.apache.karaf.config.core/${karaf.version}&lt;"
+                                        value="mvn:org.apache.karaf.config/org.apache.karaf.config.core/${org.apache.karaf.config.core.tesb.version}&lt;"/>
+                                </replace>
                                 <replace file="target/dependencies/apache-camel-${camel.version}-features.xml">
                                     <replacefilter
                                         token="apache-cxf/3.2.10/xml/features"

--- a/talend-esb/src/main/descriptors/assembly.xml
+++ b/talend-esb/src/main/descriptors/assembly.xml
@@ -206,6 +206,8 @@
                 <exclude>system/org/apache/karaf/features/enterprise/${karaf.version}/enterprise-${karaf.version}-features.xml</exclude>
                 <exclude>system/org/apache/karaf/features/spring/${karaf.version}/spring-${karaf.version}-features.xml</exclude>
                 <exclude>system/org/apache/karaf/features/spring-legacy/${karaf.version}/spring-legacy-${karaf.version}-features.xml</exclude>
+                <exclude>system/org/apache/karaf/features/standard/${karaf.version}/standard-${karaf.version}-features.xml</exclude>
+                <exclude>system/org/apache/karaf/config/org.apache.karaf.config.core/${karaf.version}/**</exclude>
                 <exclude>README.md</exclude>
                 <exclude>RELEASE-NOTES.md</exclude>
                 <exclude>BUILDING.md</exclude>
@@ -382,6 +384,8 @@
                 <exclude>org/apache/karaf/decanter/apache-karaf-decanter/${decanter.version}/apache-karaf-decanter-${decanter.version}-features.xml</exclude>
                 <exclude>org/apache/karaf/decanter/appender/org.apache.karaf.decanter.appender.jms/${decanter.version}/**</exclude>
                 <exclude>org/apache/karaf/decanter/collector/org.apache.karaf.decanter.collector.jms/${decanter.version}/**</exclude>
+                <exclude>org/apache/karaf/features/standard/${karaf.version}/standard-${karaf.version}-features.xml</exclude>
+                <exclude>org/apache/karaf/config/org.apache.karaf.config.core/${karaf.version}/**</exclude>
             </excludes>
         </fileSet>
         <!-- Woraround for xjc-utils version (TESB-21746) -->
@@ -672,6 +676,17 @@
         <file>
             <source>${basedir}/target/dependencies/jackson-module-scala_2.11-${jackson.version}.jar</source>
             <outputDirectory>./container/system/com/fasterxml/jackson/module/jackson-module-scala_2.11/${jackson.version}/</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>${basedir}/target/dependencies/standard-${karaf.version}-features.xml</source>
+            <outputDirectory>./container/system/org/apache/karaf/features/standard/${karaf.version}/</outputDirectory>
+            <fileMode>0644</fileMode>
+            <lineEnding>unix</lineEnding>
+        </file>
+        <file>
+            <source>${basedir}/target/dependencies/org.apache.karaf.config.core-${org.apache.karaf.config.core.tesb.version}.jar</source>
+            <outputDirectory>./container/system/org/apache/karaf/config/org.apache.karaf.config.core/${org.apache.karaf.config.core.tesb.version}/</outputDirectory>
             <fileMode>0644</fileMode>
         </file>
     </files>


### PR DESCRIPTION
…RemoteEngine

Use artifact `org.apache.karaf.config:org.apache.karaf.config.core:4.2.7.tesb1` which contains TESB-27385 fix.