### PR TITLE
feat(TESB-27620) Update to dom4j 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,8 @@
         <slf4j.version>1.7.12</slf4j.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.9</commons-lang3.version>
-        <dom4j.bundle.version>1.6.1_5</dom4j.bundle.version>
-        <jaxen.bundle.version>1.1.1_2</jaxen.bundle.version>
+        <dom4j.bundle.version>2.1.1_1</dom4j.bundle.version>
+        <jaxen.bundle.version>1.1.6_1</jaxen.bundle.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <commons-pool.version>1.6</commons-pool.version>
         <!-- check compatible version -->

--- a/talend-esb/pom.xml
+++ b/talend-esb/pom.xml
@@ -1154,6 +1154,10 @@
                                     <replacefilter
                                         token="mvn:com.fasterxml.jackson.module/jackson-module-jsonSchema/2.9.9"
                                         value="mvn:com.fasterxml.jackson.module/jackson-module-jsonSchema/${jackson.version}"/>
+                                    <!-- patch the dom4j version in Camel for TESB-27620 -->
+                                    <replacefilter
+                                        token="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/1.6.1_5"
+                                        value="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${dom4j.bundle.version}"/>
                                 </replace>
                                 <!-- Patch jetty version range in Camel features (TESB-18114/CAMEL-10433) -->
                                 <replaceregexp byline="false" flags="gim"
@@ -1238,6 +1242,10 @@
                                     <replacefilter
                                         token="mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.9.10"
                                         value="mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson.version}"/>
+                                    <!-- patch the dom4j version in CXF for TESB-27620 -->
+                                    <replacefilter
+                                        token="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/1.6.1_5"
+                                        value="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${dom4j.bundle.version}"/>
                                 </replace>
                                 <!-- patch the cxf-jackson feature (TESB-27214/CXF-8155) -->
                                 <replaceregexp byline="false" flags="gim"


### PR DESCRIPTION
jaxen also has to be upgraded from 1.1.1 to 1.1.6 as the dom4j 2.1.1 requires org.jaxen [1.1.6,2)
and the cxf/camel features xml have to be patched.