### PR TITLE
TESB-27953 - Fix tesb-rt-se Camel examples

### DIFF
--- a/examples/camel/claimcheck/pom.xml
+++ b/examples/camel/claimcheck/pom.xml
@@ -36,18 +36,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-osgi</artifactId>
-                <version>${activemq.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
                 <version>${spring.version}</version>

--- a/examples/camel/claimcheck/server/pom.xml
+++ b/examples/camel/claimcheck/server/pom.xml
@@ -36,7 +36,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Require-Bundle>org.springframework.beans,org.apache.activemq.activemq-osgi</Require-Bundle>
                     </instructions>
                 </configuration>
             </plugin>
@@ -69,12 +68,6 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-osgi</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/examples/camel/jaxrs-jms-http/client/pom.xml
+++ b/examples/camel/jaxrs-jms-http/client/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-spring</artifactId>
         </dependency>
         <dependency>
@@ -53,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-jetty</artifactId>
+            <artifactId>camel-jetty9</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -68,12 +73,6 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-osgi</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/examples/camel/jaxrs-jms-http/pom.xml
+++ b/examples/camel/jaxrs-jms-http/pom.xml
@@ -47,7 +47,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
-                <artifactId>camel-jetty</artifactId>
+                <artifactId>camel-jetty9</artifactId>
                 <version>${camel.version}</version>
             </dependency>
             <dependency>
@@ -79,17 +79,6 @@
                 </exclusions>
             </dependency>
 
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-osgi</artifactId>
-                <version>${activemq.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-jaxrs</artifactId>

--- a/examples/camel/jaxrs-jms-http/server/pom.xml
+++ b/examples/camel/jaxrs-jms-http/server/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-jetty</artifactId>
+            <artifactId>camel-jetty9</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
@@ -59,12 +59,6 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-osgi</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 
@@ -102,7 +96,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Require-Bundle>org.apache.camel.camel-cxf,org.apache.camel.camel-cxf-transport,org.apache.cxf.bundle,org.apache.camel.camel-cxf,org.springframework.beans,org.apache.activemq.activemq-osgi</Require-Bundle>
                     </instructions>
                 </configuration>
             </plugin>

--- a/examples/camel/jaxrs-jms-http/server/src/main/resources/META-INF/spring/beans.xml
+++ b/examples/camel/jaxrs-jms-http/server/src/main/resources/META-INF/spring/beans.xml
@@ -80,7 +80,7 @@
     <bean id="stripPrefix" class="service.StripPrefixProcessor">
     </bean>
 
-    <bean id="jetty" class="org.apache.camel.component.jetty.JettyHttpComponent">
+    <bean id="jetty" class="org.apache.camel.component.jetty9.JettyHttpComponent9">
     </bean>
     
 </beans>

--- a/examples/camel/jaxws-jms/client/pom.xml
+++ b/examples/camel/jaxws-jms/client/pom.xml
@@ -44,12 +44,6 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-osgi</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- logging -->

--- a/examples/camel/jaxws-jms/pom.xml
+++ b/examples/camel/jaxws-jms/pom.xml
@@ -64,17 +64,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-osgi</artifactId>
-                <version>${activemq.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-jaxws</artifactId>
                 <version>${cxf.version}</version>

--- a/examples/camel/jaxws-jms/server/pom.xml
+++ b/examples/camel/jaxws-jms/server/pom.xml
@@ -72,8 +72,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Import-Package>*,org.apache.camel.osgi</Import-Package>
-                        <Require-Bundle>org.apache.camel.camel-cxf,org.apache.camel.camel-cxf-transport,org.apache.cxf.bundle,org.springframework.beans,org.apache.activemq.activemq-osgi,org.apache.camel.camel-cxf</Require-Bundle>
+                        <Import-Package>*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/examples/camel/pom.xml
+++ b/examples/camel/pom.xml
@@ -22,7 +22,6 @@
     <properties>
         <spring.version>5.1.9.RELEASE</spring.version>
         <spring.security.version>5.1.5.RELEASE</spring.security.version>
-        <jetty.version>9.4.22.v20191022</jetty.version>
         <jsr311.api.version>1.1.1</jsr311.api.version>
         <jsr250.api.version>1.0</jsr250.api.version>
         <felix.version>1.2.0</felix.version>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -99,6 +99,29 @@
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-osgi</artifactId>
+                <version>${activemq.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.activemq</groupId>
+                        <artifactId>activemq-leveldb-store</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
All of the Camel examples are now working apart from spring-security, which I have not been able to easily fix. I excluded some unused jars from activemq-osgi that were causing Veracode to flag some CVEs.