### PR TITLE
TESB-28064: Runtime Container - start.bat should not open an additina…

### DIFF
--- a/talend-esb/src/main/bin/start.bat
+++ b/talend-esb/src/main/bin/start.bat
@@ -86,7 +86,8 @@ if "%KARAF_TITLE%" == "" (
 )
 
 :EXECUTE
-    start "%KARAF_TITLE%" /MIN "%KARAF_HOME%\bin\trun.bat" server %*
+    rem fixed TESB-5752 removing "start ..." to avoid open a new window
+    "%KARAF_HOME%\bin\trun.bat" server %*
 
 rem # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 


### PR DESCRIPTION
…l cmd window

Introduced with latest karaf executables update.
Setting back the previous execution without new terminal opening.