### PR TITLE
TESB-21943 correct groupId

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -207,7 +207,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.mortbay.jetty</groupId>
+                    <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
                 </plugin>


### PR DESCRIPTION
replace org.mortbay.jetty by org.eclipse.jetty for artifact jetty-maven-plugin.

maven-jetty-plugin with version 6.x/7.x is in group org.mortbay.jetty.
jetty-maven-plugin with version 9.x and higher are in group org.eclipse.jetty.