### PR TITLE
jill/Bugfix/maintenance/6.4/TESB-21943 correct group id

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -150,7 +150,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.mortbay.jetty</groupId>
+                    <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
                 </plugin>

--- a/examples/tesb/locator-service/soap-service/war/pom.xml
+++ b/examples/tesb/locator-service/soap-service/war/pom.xml
@@ -59,7 +59,7 @@
         <finalName>services</finalName>
 	    <plugins>
 		    <plugin>
-		        <groupId>org.mortbay.jetty</groupId>
+		        <groupId>org.eclipse.jetty</groupId>
 		        <artifactId>jetty-maven-plugin</artifactId>
 <!--
 		        <configuration>


### PR DESCRIPTION
replace org.mortbay.jetty by org.eclipse.jetty for artifact jetty-maven-plugin.

maven-jetty-plugin with version 6.x/7.x is in group org.mortbay.jetty.
jetty-maven-plugin with version 9.x and higher are in group org.eclipse.jetty.