### PR TITLE
jill/Bugfix/maintenance/7.0/TESB-21943 correct group id

### DIFF
--- a/examples/camel/claimcheck/war/pom.xml
+++ b/examples/camel/claimcheck/war/pom.xml
@@ -20,7 +20,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
                 <configuration>

--- a/examples/camel/jaxrs-jms-http/war/pom.xml
+++ b/examples/camel/jaxrs-jms-http/war/pom.xml
@@ -49,7 +49,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
                 <configuration>

--- a/examples/camel/jaxws-jms/war/pom.xml
+++ b/examples/camel/jaxws-jms/war/pom.xml
@@ -40,7 +40,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
                 <configuration>

--- a/examples/camel/spring-security/war/pom.xml
+++ b/examples/camel/spring-security/war/pom.xml
@@ -56,7 +56,7 @@
     	<finalName>spring-security</finalName>
         <plugins>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
                 <configuration>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -149,7 +149,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.mortbay.jetty</groupId>
+                    <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
                 </plugin>

--- a/examples/tesb/locator-service/soap-service/war/pom.xml
+++ b/examples/tesb/locator-service/soap-service/war/pom.xml
@@ -59,7 +59,7 @@
         <finalName>services</finalName>
 	    <plugins>
 		    <plugin>
-		        <groupId>org.mortbay.jetty</groupId>
+		        <groupId>org.eclipse.jetty</groupId>
 		        <artifactId>jetty-maven-plugin</artifactId>
 <!--
 		        <configuration>

--- a/examples/tesb/locator/war/pom.xml
+++ b/examples/tesb/locator/war/pom.xml
@@ -66,7 +66,7 @@
         <finalName>services</finalName>
 	    <plugins>
 		    <plugin>
-		        <groupId>org.mortbay.jetty</groupId>
+		        <groupId>org.eclipse.jetty</groupId>
 		        <artifactId>jetty-maven-plugin</artifactId>
 
 		        <configuration>

--- a/examples/tesb/sam/sam-example-service/pom.xml
+++ b/examples/tesb/sam/sam-example-service/pom.xml
@@ -74,7 +74,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
                     <connectors>

--- a/examples/tesb/sam/sam-example-service2/pom.xml
+++ b/examples/tesb/sam/sam-example-service2/pom.xml
@@ -74,7 +74,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
                     <connectors>

--- a/examples/tesb/sam/sam-server-jetty/pom.xml
+++ b/examples/tesb/sam/sam-server-jetty/pom.xml
@@ -55,7 +55,7 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.mortbay.jetty</groupId>
+				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
 				<configuration>
 					<systemProperties>


### PR DESCRIPTION
replace org.mortbay.jetty by org.eclipse.jetty for artifact jetty-maven-plugin.

maven-jetty-plugin with version 6.x/7.x is in group org.mortbay.jetty.
jetty-maven-plugin with version 9.x and higher are in group org.eclipse.jetty.