### PR TITLE
Remove redundant dependencies

### DIFF
--- a/auxiliary-storage/commands/pom.xml
+++ b/auxiliary-storage/commands/pom.xml
@@ -39,12 +39,36 @@
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
             <version>${karaf.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>org.apache.karaf.features.core</artifactId>
             <version>${karaf.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.base</groupId>
+                    <artifactId>ops4j-base-util-collections</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
@jgreffe Hi, I am a user of project **_org.talend.esb.auxiliary.storage:auxiliary-storage-commands:7.4.1-SNAPSHOT_**. I found that its pom file introduced **_31_** dependencies. However, among them, **_7_** libraries (**_22%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.talend.esb.auxiliary.storage:auxiliary-storage-commands:7.4.1-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.glassfish.jaxb:txw2:jar:2.3.3:compile
com.sun.activation:jakarta.activation:jar:1.2.2:runtime
jakarta.activation:jakarta.activation-api:jar:1.2.2:compile
org.glassfish.jaxb:jaxb-runtime:jar:2.3.3:compile
org.ops4j.base:ops4j-base-util-collections:jar:1.5.1:compile
com.sun.istack:istack-commons-runtime:jar:3.0.11:compile
jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:compile
</code></pre>