### PR TITLE
TPRUN-1328 Restrict JMX and SSH access to localhost.

### DIFF
--- a/talend-esb/src/main/distribution/text/container/etc/org.apache.karaf.management.cfg
+++ b/talend-esb/src/main/distribution/text/container/etc/org.apache.karaf.management.cfg
@@ -22,27 +22,27 @@
 #
 # Port number for RMI registry connection
 #
-rmiRegistryPort = 1099
+rmiRegistryPort = ${env:ORG_APACHE_KARAF_MANAGEMENT_RMIREGISTRYPORT:-1099}
 
 #
 # Host for RMI registry
 #
-rmiRegistryHost = 0.0.0.0
+rmiRegistryHost = ${env:ORG_APACHE_KARAF_MANAGEMENT_RMIREGISTRYHOST:-127.0.0.1}
 
 #
 # Port number for RMI server connection
 #
-rmiServerPort = 44444
+rmiServerPort = ${env:ORG_APACHE_KARAF_MANAGEMENT_RMISERVERPORT:-44444}
 
 #
 # Host for RMI server
 #
-rmiServerHost = 0.0.0.0
+rmiServerHost = ${env:ORG_APACHE_KARAF_MANAGEMENT_RMISERVERHOST:-127.0.0.1}
 
 #
 # Name of the JAAS realm used for authentication
 #
-jmxRealm = karaf
+jmxRealm = ${env:ORG_APACHE_KARAF_MANAGEMENT_JMXREALM:-karaf}
 
 #
 # The service URL for the JMXConnectorServer
@@ -50,19 +50,44 @@ jmxRealm = karaf
 serviceUrl = service:jmx:rmi://${rmiServerHost}:${rmiServerPort}/jndi/rmi://${rmiRegistryHost}:${rmiRegistryPort}/karaf-${karaf.name}
 
 #
+# JMXMP connector enabled
+#
+jmxmpEnabled = ${env:ORG_APACHE_KARAF_MANAGEMENT_JMXMPENABLED:-false}
+
+#
+# JMXMP connector host name
+#
+jmxmpHost = ${env:ORG_APACHE_KARAF_MANAGEMENT_JMXMPHOST:-127.0.0.1}
+
+#
+# JMXMP connector port number
+#
+jmxmpPort = ${env:ORG_APACHE_KARAF_MANAGEMENT_JMXMPPORT:-9999}
+
+#
+# JMXMP connector service URL
+#
+jmxmpServiceUrl = service:jmx:jmxmp://${jmxmpHost}:${jmxmpPort}
+
+#
 # Whether any threads started for the JMXConnectorServer should be started as daemon threads
 #
-daemon = true
+daemon = ${env:ORG_APACHE_KARAF_MANAGEMENT_DAEMON:-true}
 
 #
 # Whether the JMXConnectorServer should be started in a separate thread
 #
-threaded = true
+threaded = ${env:ORG_APACHE_KARAF_MANAGEMENT_THREADED:-true}
 
 #
 # The ObjectName used to register the JMXConnectorServer
 #
 objectName = connector:name=rmi
+
+#
+# The ObjectName used to register the JMXMP connector
+#
+jmxmpObjectName = connector:name=jmxmp
 
 #
 # Timeout to lookup for the keystore in case of SSL authentication usage

--- a/talend-esb/src/main/distribution/text/container/etc/org.apache.karaf.shell.cfg
+++ b/talend-esb/src/main/distribution/text/container/etc/org.apache.karaf.shell.cfg
@@ -25,24 +25,34 @@
 #
 # Via sshPort and sshHost you define the address you can login into Karaf.
 #
-sshPort = 8101
-sshHost = 0.0.0.0
+sshPort = ${env:ORG_APACHE_KARAF_SSH_SSHPORT:-8101}
+sshHost = ${env:ORG_APACHE_KARAF_SSH_SSHHOST:-127.0.0.1}
 
 #
 # The sshIdleTimeout defines the inactivity timeout to logout the SSH session.
 # The sshIdleTimeout is in milliseconds, and the default is set to 30 minutes.
 #
-sshIdleTimeout = 1800000
+sshIdleTimeout = ${env:ORG_APACHE_KARAF_SSH_SSHIDLETIMEOUT:-1800000}
+
+#
+# Define the number of the NIO workers for the sshd server. Default is 2.
+#
+#nio-workers = 2
+
+#
+# Define the maximum number of SSH sessions. Default is unlimited.
+#
+#max-concurrent-sessions = -1
 
 #
 # sshRealm defines which JAAS domain to use for password authentication.
 #
-sshRealm = karaf
+sshRealm = ${env:ORG_APACHE_KARAF_SSH_SSHREALM:-karaf}
 
 #
 # Defines if the SFTP system is enabled or not in the SSH server
 #
-sftpEnabled=true
+sftpEnabled = ${env:ORG_APACHE_KARAF_SSH_SFTPENABLED:-true}
 
 #
 # The location of the hostKey file defines where the private/public key of the server
@@ -59,7 +69,7 @@ hostKeyFormat = simple
 #
 # shRole defines the role required to access the console through ssh
 #
-sshRole = admin
+sshRole = ${env:ORG_APACHE_KARAF_SSH_SSHROLE:-admin}
 
 #
 # Self defined key size in 1024, 2048, 3072, or 4096
@@ -80,7 +90,7 @@ sshRole = admin
 # 3: DEBUG
 # 4: TRACE
 #
-#logLevel=1
+#logLevel = 1
 
 #
 # Specify an additional welcome banner to be displayed when a user logs into the server.
@@ -98,6 +108,7 @@ sshRole = admin
 # This property define the default value when you use the Karaf shell console.
 # You can change the completion mode directly in the shell console, using shell:completion command.
 #
+completionMode = ${env:ORG_APACHE_KARAF_SHELL_COMPLETIONMODE:-GLOBAL}
 
 #
 # Override allowed SSH cipher algorithms.
@@ -122,6 +133,4 @@ sshRole = admin
 # Default: moduli-url not specified to use the internal one from SSHD
 #
 # moduli-url = external moduli-url users wanna use
-
-completionMode = GLOBAL
 


### PR DESCRIPTION
Furtthermore, the updated configurations allow parameter override by OS environment variables in the same way as the remote engine (gen 1).